### PR TITLE
Add functionality to start django tests with searching free port in system.

### DIFF
--- a/hstest/django_test.py
+++ b/hstest/django_test.py
@@ -1,18 +1,59 @@
 import os
 import signal
 import subprocess
+from time import sleep
+from urllib.error import URLError, HTTPError
+from urllib.request import urlopen
 from hstest.stage_test import StageTest
+from hstest.check_result import CheckResult
 
 
 class DjangoTest(StageTest):
 
     _kill = os.kill
+    port = '0'
+    tryout_ports = ['8000', '8001', '8002', '8003', '8004']
     process = None
 
     def run(self):
         if self.process is None:
-            self.process = subprocess.Popen([self.file_to_test, 'runserver'])
+            self.__find_free_port()
+            self.process = subprocess.Popen([
+                self.file_to_test,
+                'runserver', self.port, '--noreload',
+            ])
+
+    def check_server(self):
+        if self.port == '0':
+            return CheckResult.false(
+                f'Please free one of the ports: {", ".join(self.tryout_ports)}'
+            )
+
+        for _ in range(15):
+            try:
+                urlopen(f'http://localhost:{self.port}/not-existing-link-by-default')
+                return CheckResult.true()
+            except URLError as err:
+                if isinstance(err, HTTPError):
+                    return CheckResult.true()
+                sleep(1)
+        else:
+            return CheckResult.false(
+                'Cannot start the ./manage.py runserver for 15 seconds'
+            )
+
+    def __find_free_port(self):
+        for port in self.tryout_ports:
+            try:
+                urlopen(f'http://localhost:{port}')
+            except URLError as err:
+                if isinstance(err.reason, ConnectionRefusedError):
+                    self.port = port
+                    break
 
     def after_all_tests(self):
         if self.process is not None:
-            self._kill(self.process.pid, signal.SIGINT)
+            try:
+                self._kill(self.process.pid, signal.SIGINT)
+            except ProcessLookupError:
+                pass


### PR DESCRIPTION
Add first test that passed if response to not existing link
raises HttpError(expected to be 404) or is completely correct