### PR TITLE
HSPC-47 allow not to catch stderr

### DIFF
--- a/hstest/dynamic/output/output_handler.py
+++ b/hstest/dynamic/output/output_handler.py
@@ -57,7 +57,7 @@ class OutputHandler:
         OutputHandler._real_err = sys.stderr
 
         OutputHandler._mock_out = OutputMock(sys.stdout)
-        OutputHandler._mock_err = OutputMock(sys.stderr)
+        OutputHandler._mock_err = OutputMock(sys.stderr, is_stderr=True)
 
         sys.stdout = OutputHandler._mock_out
         sys.stderr = OutputHandler._mock_err

--- a/hstest/dynamic/output/output_mock.py
+++ b/hstest/dynamic/output/output_mock.py
@@ -1,5 +1,4 @@
 import io
-import sys
 from typing import Any, Dict, List, TYPE_CHECKING
 
 from hstest.dynamic.output.colored_output import BLUE, RESET

--- a/hstest/dynamic/output/output_mock.py
+++ b/hstest/dynamic/output/output_mock.py
@@ -1,10 +1,12 @@
 import io
+import sys
 from typing import Any, Dict, List, TYPE_CHECKING
 
 from hstest.dynamic.output.colored_output import BLUE, RESET
 from hstest.dynamic.output.infinite_loop_detector import loop_detector
 from hstest.exception.outcomes import UnexpectedError
 from hstest.testing.execution_options import ignore_stdout
+from hstest.testing.settings import Settings
 
 if TYPE_CHECKING:
     from hstest.dynamic.input.input_mock import Condition
@@ -35,6 +37,7 @@ class OutputMock:
         class RealOutputMock:
             def __init__(self, out: io.TextIOWrapper):
                 self.out = out
+                self.name = 'stderr' if out == sys.stderr else 'stdout'
 
             def write(self, text):
                 if not ignore_stdout:
@@ -76,9 +79,10 @@ class OutputMock:
             self._original.write(BLUE + text + RESET)
             return
 
-        self._original.write(text)
-        self._cloned.append(text)
-        self._dynamic.append(text)
+        if self._original.name != 'stderr' or Settings.catch_stderr:
+            self._original.write(text)
+            self._cloned.append(text)
+            self._dynamic.append(text)
         partial_handler.append(text)
 
         loop_detector.write(text)

--- a/hstest/dynamic/output/output_mock.py
+++ b/hstest/dynamic/output/output_mock.py
@@ -33,11 +33,10 @@ class OutputMock:
     but also injected input from the test
     """
 
-    def __init__(self, real_out: io.TextIOWrapper):
+    def __init__(self, real_out: io.TextIOWrapper, is_stderr: bool = False):
         class RealOutputMock:
             def __init__(self, out: io.TextIOWrapper):
                 self.out = out
-                self.name = 'stderr' if out == sys.stderr else 'stdout'
 
             def write(self, text):
                 if not ignore_stdout:
@@ -53,6 +52,7 @@ class OutputMock:
         self._cloned: List[str] = []
         self._dynamic: List[str] = []
         self._partial: Dict[Any, ConditionalOutput] = {}
+        self._is_stderr = is_stderr
 
     @property
     def original(self):
@@ -79,11 +79,11 @@ class OutputMock:
             self._original.write(BLUE + text + RESET)
             return
 
-        if self._original.name != 'stderr' or Settings.catch_stderr:
+        if not self._is_stderr or Settings.catch_stderr:
             self._original.write(text)
             self._cloned.append(text)
             self._dynamic.append(text)
-        partial_handler.append(text)
+            partial_handler.append(text)
 
         loop_detector.write(text)
 

--- a/hstest/dynamic/output/output_mock.py
+++ b/hstest/dynamic/output/output_mock.py
@@ -48,9 +48,9 @@ class OutputMock:
                 self.out.close()
 
         self._original: RealOutputMock = RealOutputMock(real_out)
-        self._cloned: List[str] = []
-        self._dynamic: List[str] = []
-        self._partial: Dict[Any, ConditionalOutput] = {}
+        self._cloned: List[str] = []  # used in check function
+        self._dynamic: List[str] = []  # used to append inputs
+        self._partial: Dict[Any, ConditionalOutput] = {}  # used to separate outputs for each program
         self._is_stderr = is_stderr
 
     @property

--- a/hstest/testing/settings.py
+++ b/hstest/testing/settings.py
@@ -1,8 +1,7 @@
-
 class Settings:
-
     do_reset_output: bool = True
     allow_out_of_input: bool = False
+    catch_stderr: bool = True
 
     def __init__(self):
         raise NotImplementedError('Instances of the class Settings are prohibited')

--- a/tests/outcomes/stderr/disable_catching_stderr/main.py
+++ b/tests/outcomes/stderr/disable_catching_stderr/main.py
@@ -1,0 +1,3 @@
+import sys
+
+print('text from stderr', file=sys.stderr)

--- a/tests/outcomes/stderr/disable_catching_stderr/test.py
+++ b/tests/outcomes/stderr/disable_catching_stderr/test.py
@@ -2,8 +2,6 @@ from hstest.testing.unittest.user_error_test import UserErrorTest
 from hstest.testing.settings import Settings
 from hstest import dynamic_test, TestedProgram, wrong
 
-Settings.catch_stderr = False
-
 
 class TestDisableStderrCatch(UserErrorTest):
     not_contain = [
@@ -13,9 +11,8 @@ class TestDisableStderrCatch(UserErrorTest):
 
     @dynamic_test
     def test(self):
+        Settings.catch_stderr = False
         program = TestedProgram()
         program.start()
-        return wrong('Something is wrong!')
-
-    def after_all_tests(self):
         Settings.catch_stderr = True
+        return wrong('Something is wrong!')

--- a/tests/outcomes/stderr/disable_catching_stderr/test.py
+++ b/tests/outcomes/stderr/disable_catching_stderr/test.py
@@ -1,0 +1,21 @@
+from hstest.testing.unittest.user_error_test import UserErrorTest
+from hstest.testing.settings import Settings
+from hstest import dynamic_test, TestedProgram, wrong
+
+Settings.catch_stderr = False
+
+
+class TestDisableStderrCatch(UserErrorTest):
+    not_contain = [
+        'stderr:',
+        'text from stderr'
+    ]
+
+    @dynamic_test
+    def test(self):
+        program = TestedProgram()
+        program.start()
+        return wrong('Something is wrong!')
+
+    def after_all_tests(self):
+        Settings.catch_stderr = True

--- a/tests/outcomes/stderr/dynamically_change_stderr_catching/main.py
+++ b/tests/outcomes/stderr/dynamically_change_stderr_catching/main.py
@@ -1,0 +1,3 @@
+import sys
+
+print('text from stderr', file=sys.stderr)

--- a/tests/outcomes/stderr/dynamically_change_stderr_catching/test.py
+++ b/tests/outcomes/stderr/dynamically_change_stderr_catching/test.py
@@ -2,8 +2,6 @@ from hstest.testing.unittest.user_error_test import UserErrorTest
 from hstest.testing.settings import Settings
 from hstest import dynamic_test, TestedProgram, wrong
 
-Settings.catch_stderr = False
-
 
 class TestDynamicStderrCatch(UserErrorTest):
     contain = [
@@ -13,6 +11,7 @@ class TestDynamicStderrCatch(UserErrorTest):
 
     @dynamic_test
     def test(self):
+        Settings.catch_stderr = False
         program = TestedProgram()
         program.start()
 
@@ -23,7 +22,5 @@ class TestDynamicStderrCatch(UserErrorTest):
         Settings.catch_stderr = False
         program = TestedProgram()
         program.start()
-        return wrong('Something is wrong!')
-
-    def after_all_tests(self):
         Settings.catch_stderr = True
+        return wrong('Something is wrong!')

--- a/tests/outcomes/stderr/dynamically_change_stderr_catching/test.py
+++ b/tests/outcomes/stderr/dynamically_change_stderr_catching/test.py
@@ -1,0 +1,29 @@
+from hstest.testing.unittest.user_error_test import UserErrorTest
+from hstest.testing.settings import Settings
+from hstest import dynamic_test, TestedProgram, wrong
+
+Settings.catch_stderr = False
+
+
+class TestDynamicStderrCatch(UserErrorTest):
+    contain = [
+        'stderr:',
+        'text from stderr'
+    ]
+
+    @dynamic_test
+    def test(self):
+        program = TestedProgram()
+        program.start()
+
+        Settings.catch_stderr = True
+        program = TestedProgram()
+        program.start()
+
+        Settings.catch_stderr = False
+        program = TestedProgram()
+        program.start()
+        return wrong('Something is wrong!')
+
+    def after_all_tests(self):
+        Settings.catch_stderr = True


### PR DESCRIPTION
Task: [#HSPC-47](https://vyahhi.myjetbrains.com/youtrack/issue/HSPC-47)

**Reviewers**
- [ ] @meanmail 

**Description**

Add setting that allows to dynamically stop catching stderr from user program. It's required for Bash scripts where some command executions print results to stderr, even if it's not an actual error.