### PR TITLE
HSPC-55 make initial idle wait parameters global

### DIFF
--- a/hstest/testing/process_wrapper.py
+++ b/hstest/testing/process_wrapper.py
@@ -16,6 +16,9 @@ from hstest.exception.outcomes import UnexpectedError
 
 
 class ProcessWrapper:
+    initial_idle_wait = False
+    initial_idle_wait_time = 150
+
     def __init__(self, *args, check_early_finish=False, register_output=True,
                  register_io_handler=False):
         self.lock = Lock()
@@ -38,9 +41,6 @@ class ProcessWrapper:
 
         self.output_diff_history = []
         self.output_diff_history_max = 2
-
-        self.initial_idle_wait = True
-        self.initial_idle_wait_time = 150
 
         self.check_early_finish = check_early_finish
         self.register_output = register_output

--- a/hstest/testing/process_wrapper.py
+++ b/hstest/testing/process_wrapper.py
@@ -16,7 +16,7 @@ from hstest.exception.outcomes import UnexpectedError
 
 
 class ProcessWrapper:
-    initial_idle_wait = False
+    initial_idle_wait = True
     initial_idle_wait_time = 150
 
     def __init__(self, *args, check_early_finish=False, register_output=True,


### PR DESCRIPTION
Task: [#HSPC-55](https://vyahhi.myjetbrains.com/youtrack/issue/HSPC-55)

**Reviewers**
- [ ] @meanmail 

**Description**
Make initial idle wait parameters global, so they can be changed from the tests.